### PR TITLE
名前入力とチェックインまでを雑に実装

### DIFF
--- a/app/models/invited_user.rb
+++ b/app/models/invited_user.rb
@@ -4,10 +4,11 @@
 #
 # Table name: invited_users
 #
-#  id         :bigint           not null, primary key
-#  name       :string(255)      not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id           :bigint           not null, primary key
+#  init_message :text(65535)      not null
+#  name         :string(255)      not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 # Indexes
 #

--- a/app/services/line/event_handle_service.rb
+++ b/app/services/line/event_handle_service.rb
@@ -22,6 +22,8 @@ module Line
           FollowService.new(event:, line_user:)
         when Line::Bot::Event::Unfollow
           UnfollowService.new(event:, line_user:)
+        when Line::Bot::Event::Postback
+          PostbackService.new(event:, line_user:)
         end
       end
   end

--- a/app/services/line/event_handle_service/follow_service.rb
+++ b/app/services/line/event_handle_service/follow_service.rb
@@ -2,15 +2,26 @@
 
 module Line
   class EventHandleService::FollowService
-    attr_reader :event, :line_user
+    attr_reader :event, :line_user, :refollow_flg
 
     def initialize(event:, line_user:)
       @event = event
       @line_user = line_user
+      @refollow_flg = line_user.unfollow?
     end
 
     def call
       line_user.follow!
+
+      if refollow_flg
+        # 復帰
+      else
+        # 初回登録
+        PushMessage::FirstFollowService.new(
+          event:,
+          line_user:,
+        ).call
+      end
     end
   end
 end

--- a/app/services/line/event_handle_service/message_service/text_message_service.rb
+++ b/app/services/line/event_handle_service/message_service/text_message_service.rb
@@ -10,8 +10,13 @@ module Line
     end
 
     def call
-      message = { type: "text", text: received_message }
-      client.reply_message(event["replyToken"], message)
+      if line_user.invited_user.nil?
+        CheckUserNameService.new(event:, line_user:).call
+      else
+        # 未対応のものは一旦受け取った文言を返す
+        message = { type: "text", text: received_message }
+        client.reply_message(event["replyToken"], message)
+      end
     end
 
     private

--- a/app/services/line/event_handle_service/message_service/text_message_service/check_user_name_service.rb
+++ b/app/services/line/event_handle_service/message_service/text_message_service/check_user_name_service.rb
@@ -19,7 +19,22 @@ module Line
 
     private
       def find_invited_user
-        InvitedUser.find_by!(name: event.message["text"].delete(" "))
+        # まずは完全一致で確認
+        @invited_user ||= InvitedUser.find_by(name: trimed_inputed_name)
+        return @invited_user if @invited_user
+
+        # 部分一致で検索してみる(苗字だけでもある程度反応するように)
+        candidates = InvitedUser.where("name like ?", "%#{trimed_inputed_name}%")
+        if candidates.count == 1
+          @invited_user = candidates.last
+          return @invited_user
+        end
+
+        raise ActiveRecord::RecordNotFound
+      end
+
+      def trimed_inputed_name
+        @trimed_inputed_name ||= event.message["text"].delete(" ")
       end
   end
 end

--- a/app/services/line/event_handle_service/message_service/text_message_service/check_user_name_service.rb
+++ b/app/services/line/event_handle_service/message_service/text_message_service/check_user_name_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Line
+  class EventHandleService::MessageService::TextMessageService::CheckUserNameService
+    attr_reader :event, :line_user
+
+    def initialize(event:, line_user:)
+      @event = event
+      @line_user = line_user
+    end
+
+    def call
+      invited_user = find_invited_user
+
+      PushMessage::ConfirmUserNameService.new(event:, line_user:, invited_user:).call
+    rescue ActiveRecord::RecordNotFound
+      PushMessage::UserNameNotFoundService.new(event:, line_user:).call
+    end
+
+    private
+      def find_invited_user
+        InvitedUser.find_by!(name: event.message["text"].delete(" "))
+      end
+  end
+end

--- a/app/services/line/event_handle_service/postback_service.rb
+++ b/app/services/line/event_handle_service/postback_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Line
+  class EventHandleService::PostbackService
+    attr_reader :event, :line_user
+
+    def initialize(event:, line_user:)
+      @event = event
+      @line_user = line_user
+    end
+
+    def call
+      service.call
+    end
+
+    private
+      def service
+        service_class.new(event:, line_user:, **data.delete_if { |k, _| k == :service })
+      end
+
+      def service_class
+        self.class.const_get("#{data[:service].camelize}Service")
+      end
+
+      def data
+        @data ||= URI.decode_www_form(event["postback"]["data"]).to_h.deep_symbolize_keys
+      end
+  end
+end

--- a/app/services/line/event_handle_service/postback_service/name_confirm_service.rb
+++ b/app/services/line/event_handle_service/postback_service/name_confirm_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Line
+  class EventHandleService::PostbackService::NameConfirmService
+    SERVICE_NAME = "name_confirm"
+    CMD_YES = "yes"
+    CMD_NO = "no"
+
+    attr_reader :event, :line_user, :invited_user_id, :cmd
+
+    def initialize(event:, line_user:, invited_user_id:, cmd:)
+      @event = event
+      @line_user = line_user
+      @invited_user_id = invited_user_id
+      @cmd = cmd
+    end
+
+    def call
+      case cmd
+      when CMD_YES
+        line_user.create_user_activation!(invited_user:)
+        # リッチメニューの登録
+
+        PushMessage::ApproveUserNameConfirmationService.new(event:, line_user:, invited_user:).call
+      when CMD_NO
+        PushMessage::RejectUserNameConfirmationService.new(event:, line_user:, invited_user:).call
+      end
+    end
+
+    private
+      def invited_user
+        @invited_user ||= InvitedUser.find(invited_user_id)
+      end
+  end
+end

--- a/app/services/line/push_message/approve_user_name_confirmation_service.rb
+++ b/app/services/line/push_message/approve_user_name_confirmation_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Line::PushMessage::ApproveUserNameConfirmationService
+  attr_reader :event, :line_user, :invited_user
+
+  def initialize(event:, line_user:, invited_user:)
+    @event = event
+    @line_user = line_user
+    @invited_user = invited_user
+  end
+
+  def call
+    line_client.reply_message(event["replyToken"], messages)
+  end
+
+  private
+    def messages
+      [
+        {
+          type: "text",
+          text: <<~MESSAGE.chomp
+            #{invited_user.name}様
+            本日はお越しいただきありがとうございます。
+            新郎新婦からメッセージが届いております。
+          MESSAGE
+        },
+        {
+          type: "text",
+          text: invited_user.init_message,
+        }
+      ]
+    end
+
+    def line_client
+      @line_client ||= LineClient.build
+    end
+end

--- a/app/services/line/push_message/confirm_user_name_service.rb
+++ b/app/services/line/push_message/confirm_user_name_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Line::PushMessage::ConfirmUserNameService
+  attr_reader :event, :line_user, :invited_user
+
+  def initialize(event:, line_user:, invited_user:)
+    @event = event
+    @line_user = line_user
+    @invited_user = invited_user
+  end
+
+  def call
+    line_client.reply_message(event["replyToken"], confirm_message(invited_user))
+  end
+
+  private
+    def confirm_message(invited_user)
+      {
+        type: "template",
+        altText: "this is a confirm template",
+        template: {
+          type: "confirm",
+          text: "「#{invited_user.name}」さんでお間違いないですか？",
+          actions: [
+            {
+              type: "postback",
+              label: "はい",
+              data: URI.encode_www_form(
+                service: Line::EventHandleService::PostbackService::NameConfirmService::SERVICE_NAME,
+                invited_user_id: invited_user.id,
+                cmd: Line::EventHandleService::PostbackService::NameConfirmService::CMD_YES,
+              ),
+            },
+            {
+              type: "postback",
+              label: "いいえ",
+              data: URI.encode_www_form(
+                service: Line::EventHandleService::PostbackService::NameConfirmService::SERVICE_NAME,
+                invited_user_id: invited_user.id,
+                cmd: Line::EventHandleService::PostbackService::NameConfirmService::CMD_NO,
+              ),
+            }
+          ]
+        }
+      }
+    end
+
+    def line_client
+      @line_client ||= LineClient.build
+    end
+end

--- a/app/services/line/push_message/first_follow_service.rb
+++ b/app/services/line/push_message/first_follow_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class Line::PushMessage::FirstFollowService
+  attr_reader :event, :line_user
+
+  def initialize(event:, line_user:)
+    @event = event
+    @line_user = line_user
+  end
+
+  def call
+    line_client.reply_message(event["replyToken"], first_text_message)
+    sleep(5)
+    pp line_client.push_message(line_user.line_uid, second_message)
+  end
+
+  private
+    def first_text_message
+      {
+        type: "text",
+        emojis: [
+          {
+            index: 0,
+            productId: "5ac223c6040ab15980c9b44a",
+            emojiId: "013",
+          }
+        ],
+        text: <<~MESSAGE.chomp
+        $HAPPY WEDDING
+        今日はコロナ禍の中、立松と五反田の結婚式に来てくれてありがとうございます
+        みなさんと素敵な素敵な時間を過ごせることをとてもとても楽しみにしてました！
+        本日少しでも楽しんでいただけると嬉しいです♩
+        MESSAGE
+      }
+    end
+
+    def second_message
+      {
+        type: "text",
+        text: <<~MESSAGE.chomp
+        早速ですがまずお名前の入力をお願いします！
+
+        例:
+        立松幸樹
+        五反田梓
+        MESSAGE
+      }
+    end
+
+    def line_client
+      @line_client ||= LineClient.build
+    end
+end

--- a/app/services/line/push_message/first_follow_service.rb
+++ b/app/services/line/push_message/first_follow_service.rb
@@ -11,7 +11,7 @@ class Line::PushMessage::FirstFollowService
   def call
     line_client.reply_message(event["replyToken"], first_text_message)
     sleep(5)
-    pp line_client.push_message(line_user.line_uid, second_message)
+    line_client.push_message(line_user.line_uid, second_message)
   end
 
   private

--- a/app/services/line/push_message/reject_user_name_confirmation_service.rb
+++ b/app/services/line/push_message/reject_user_name_confirmation_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Line::PushMessage::RejectUserNameConfirmationService
+  attr_reader :event, :line_user, :invited_user
+
+  def initialize(event:, line_user:, invited_user:)
+    @event = event
+    @line_user = line_user
+    @invited_user = invited_user
+  end
+
+  def call
+    line_client.reply_message(event["replyToken"], message)
+  end
+
+  private
+    def message
+      {
+        type: "text",
+        text: <<~MESSAGE.chomp
+          お手数ですが再度お名前を送信してください。
+        MESSAGE
+      }
+    end
+
+    def line_client
+      @line_client ||= LineClient.build
+    end
+end

--- a/app/services/line/push_message/user_name_not_found_service.rb
+++ b/app/services/line/push_message/user_name_not_found_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Line::PushMessage::UserNameNotFoundService
+  attr_reader :event, :line_user
+
+  def initialize(event:, line_user:)
+    @event = event
+    @line_user = line_user
+  end
+
+  def call
+    line_client.reply_message(event["replyToken"], user_not_found_message)
+  end
+
+  private
+    def user_not_found_message
+      {
+        type: "text",
+        text: <<~MESSAGE.chomp
+          申し訳ございません。
+          お名前の確認に失敗しました。
+          お手数ですが再度お名前の入力をお願いします。
+        MESSAGE
+      }
+    end
+
+    def line_client
+      @line_client ||= LineClient.build
+    end
+end

--- a/db/schema/invited_users.rb
+++ b/db/schema/invited_users.rb
@@ -2,6 +2,7 @@
 
 create_table :invited_users do |t|
   t.string :name, null: false, index: { unique: true }
+  t.text :init_message, null: false
 
   t.timestamps
 end

--- a/spec/factories/invited_users.rb
+++ b/spec/factories/invited_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: invited_users

--- a/spec/factories/invited_users.rb
+++ b/spec/factories/invited_users.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: invited_users
+#
+#  id           :bigint           not null, primary key
+#  init_message :text(65535)      not null
+#  name         :string(255)      not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_invited_users_on_name  (name) UNIQUE
+#
+FactoryBot.define do
+  factory :invited_user do
+    sequence(:name) { |i| "name#{i}" }
+    sequence(:init_message) { |i| "init_message#{i}" }
+  end
+end

--- a/spec/requests/webhook/lines_controller_spec.rb
+++ b/spec/requests/webhook/lines_controller_spec.rb
@@ -75,6 +75,7 @@ describe Webhook::LinesController do
             type: "user",
             userId: line_user.line_uid
           },
+          replyToken: "sampleReplyToken",
           mode: "active"
         }
       end
@@ -82,6 +83,27 @@ describe Webhook::LinesController do
 
       it { is_expected.to eq 200 }
       it { expect { subject }.to change { line_user.reload.follow_status }.from("follow").to("unfollow") }
+    end
+
+    context "with postback event" do
+      let!(:event) do
+        {
+          type: "postback",
+          postback: {
+            data: "service=name_confirm&invited_user_id=#{invited_user.id}&cmd=no"
+          },
+          timestamp: 1645876173427,
+          source: {
+            type: "user",
+            userId: line_user.line_uid
+          },
+          mode: "active"
+        }
+      end
+      let!(:invited_user) { create(:invited_user) }
+      let!(:line_user) { create(:line_user, line_uid: "sampleUserId") }
+
+      it { is_expected.to eq 200 }
     end
 
     context "with invalid signature" do


### PR DESCRIPTION
## 実装内容
時間がないのでspecは一旦stayとしているが以下を実装
* 友達登録時に名前を確認する通知を飛ばす
* 入力された名前からInvitedUserを弾いてきてconfirmationを行い、アクティベーションを行う